### PR TITLE
Supprime la marque BOM de sauvegardes.php

### DIFF
--- a/sauvegardes.php
+++ b/sauvegardes.php
@@ -1,4 +1,4 @@
-﻿<?php include 'includes/header.php'; ?>
+<?php include 'includes/header.php'; ?>
 
 <main class="devices-section">
   <h2 class="text-2xl mb-6">


### PR DESCRIPTION
## Summary
- Remove UTF-8 BOM and any leading spaces so `sauvegardes.php` begins directly with `<?php`

## Testing
- `php -l sauvegardes.php`


------
https://chatgpt.com/codex/tasks/task_e_68ada7ca4718832cbdffd4edd4853afe