### PR TITLE
Add greeting display modes and configurator parameters

### DIFF
--- a/greetings.md
+++ b/greetings.md
@@ -1,0 +1,18 @@
+# Greetings
+
+## Modes d’affichage
+
+1. **Au-dessus de la bulle – immédiat**
+   Le message d’accueil apparaît au-dessus de l’icône/bulle dès l’arrivée sur la page.
+2. **Au-dessus de la bulle – après délai**
+   Le message d’accueil apparaît au-dessus de la bulle après un délai configurable (par défaut 30 s).
+3. **Dans la fenêtre de chat uniquement**
+   Le message d’accueil n’apparaît qu’une fois la fenêtre de chat ouverte (première ouverture).
+
+## Paramètres du configurateur
+- `message` : texte du message d’accueil.
+- `displayMode` : mode d’affichage (`bubble_immediate`, `bubble_delayed`, `window_only`).
+- `delay` : délai en millisecondes pour le mode "après délai" (par défaut 30000).
+- `bubbleSelector` : sélecteur CSS de la bulle de chat.
+- `chatSelector` : sélecteur CSS de la fenêtre de chat.
+

--- a/widget.js
+++ b/widget.js
@@ -1,0 +1,59 @@
+/**
+ * Initialise le widget de message d'accueil.
+ * @param {Object} userConfig Configuration venant du configurateur.
+ * @param {string} userConfig.message Texte du message d'accueil.
+ * @param {string} userConfig.displayMode Mode d'affichage ('bubble_immediate', 'bubble_delayed', 'window_only').
+ * @param {number} userConfig.delay Délai en ms pour le mode "bubble_delayed".
+ * @param {string} userConfig.bubbleSelector Sélecteur CSS de la bulle de chat.
+ * @param {string} userConfig.chatSelector Sélecteur CSS de la fenêtre de chat.
+ */
+export function initGreetingWidget(userConfig = {}) {
+  const config = {
+    message: 'Bonjour !',
+    displayMode: 'bubble_immediate', // 'bubble_immediate', 'bubble_delayed', 'window_only'
+    delay: 30000,
+    bubbleSelector: '.chat-bubble',
+    chatSelector: '.chat-window',
+    ...userConfig
+  };
+
+  function createPopover() {
+    const el = document.createElement('div');
+    el.className = 'greeting-popover';
+    el.textContent = config.message;
+    return el;
+  }
+
+  function showBubbleGreeting() {
+    const bubble = document.querySelector(config.bubbleSelector);
+    if (!bubble) return;
+    const pop = createPopover();
+    bubble.parentNode.insertBefore(pop, bubble);
+  }
+
+  function showChatGreeting() {
+    const chat = document.querySelector(config.chatSelector);
+    if (!chat) return;
+    const pop = createPopover();
+    chat.appendChild(pop);
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    if (config.displayMode === 'bubble_immediate') {
+      showBubbleGreeting();
+    } else if (config.displayMode === 'bubble_delayed') {
+      setTimeout(showBubbleGreeting, config.delay);
+    } else if (config.displayMode === 'window_only') {
+      const bubble = document.querySelector(config.bubbleSelector);
+      if (bubble) {
+        bubble.addEventListener(
+          'click',
+          () => {
+            showChatGreeting();
+          },
+          { once: true }
+        );
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Document new greeting display modes and configurator options
- Implement greeting widget honoring configurator parameters and display modes

## Testing
- `node --check widget.js`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68af60e5e450832cabe1f6d74f64111e