### PR TITLE
feat: enhance greeting configurator

### DIFF
--- a/greetings.md
+++ b/greetings.md
@@ -5,14 +5,16 @@
 1. **Au-dessus de la bulle – immédiat**
    Le message d’accueil apparaît au-dessus de l’icône/bulle dès l’arrivée sur la page.
 2. **Au-dessus de la bulle – après délai**
-   Le message d’accueil apparaît au-dessus de la bulle après un délai configurable (par défaut 30 s).
+   Le message d’accueil apparaît au-dessus de la bulle après un délai configurable (par défaut 30 s).
 3. **Dans la fenêtre de chat uniquement**
    Le message d’accueil n’apparaît qu’une fois la fenêtre de chat ouverte (première ouverture).
 
 ## Paramètres du configurateur
 - `message` : texte du message d’accueil.
 - `displayMode` : mode d’affichage (`bubble_immediate`, `bubble_delayed`, `window_only`).
-- `delay` : délai en millisecondes pour le mode "après délai" (par défaut 30000).
+- `delay` : délai en secondes pour le mode "après délai" (par défaut 30).
+- `quickReplies` : liste des réponses rapides affichées sous le message, dans l’ordre fourni.
+- `closable` : booléen indiquant si le message est fermable (par défaut true).
 - `bubbleSelector` : sélecteur CSS de la bulle de chat.
 - `chatSelector` : sélecteur CSS de la fenêtre de chat.
 

--- a/widget.js
+++ b/widget.js
@@ -3,7 +3,9 @@
  * @param {Object} userConfig Configuration venant du configurateur.
  * @param {string} userConfig.message Texte du message d'accueil.
  * @param {string} userConfig.displayMode Mode d'affichage ('bubble_immediate', 'bubble_delayed', 'window_only').
- * @param {number} userConfig.delay Délai en ms pour le mode "bubble_delayed".
+ * @param {number} userConfig.delay Délai en secondes pour le mode "bubble_delayed" (défaut 30).
+ * @param {string[]} userConfig.quickReplies Libellés des réponses rapides (affichées dans l'ordre fourni).
+ * @param {boolean} userConfig.closable Message fermable ou non (défaut true).
  * @param {string} userConfig.bubbleSelector Sélecteur CSS de la bulle de chat.
  * @param {string} userConfig.chatSelector Sélecteur CSS de la fenêtre de chat.
  */
@@ -11,7 +13,9 @@ export function initGreetingWidget(userConfig = {}) {
   const config = {
     message: 'Bonjour !',
     displayMode: 'bubble_immediate', // 'bubble_immediate', 'bubble_delayed', 'window_only'
-    delay: 30000,
+    delay: 30, // en secondes
+    quickReplies: [],
+    closable: true,
     bubbleSelector: '.chat-bubble',
     chatSelector: '.chat-window',
     ...userConfig
@@ -20,7 +24,37 @@ export function initGreetingWidget(userConfig = {}) {
   function createPopover() {
     const el = document.createElement('div');
     el.className = 'greeting-popover';
-    el.textContent = config.message;
+
+    const msgEl = document.createElement('div');
+    msgEl.className = 'greeting-message';
+    msgEl.textContent = config.message;
+    el.appendChild(msgEl);
+
+    if (config.closable) {
+      const closeBtn = document.createElement('button');
+      closeBtn.className = 'greeting-close';
+      closeBtn.textContent = '\u00d7';
+      closeBtn.addEventListener('click', () => el.remove());
+      el.appendChild(closeBtn);
+    }
+
+    if (Array.isArray(config.quickReplies) && config.quickReplies.length > 0) {
+      const repliesEl = document.createElement('div');
+      repliesEl.className = 'greeting-quick-replies';
+      config.quickReplies.forEach((label) => {
+        const btn = document.createElement('button');
+        btn.className = 'greeting-quick-reply';
+        btn.textContent = label;
+        btn.addEventListener('click', () => {
+          const evt = new CustomEvent('greeting-quick-reply', { detail: { label } });
+          document.dispatchEvent(evt);
+          el.remove();
+        });
+        repliesEl.appendChild(btn);
+      });
+      el.appendChild(repliesEl);
+    }
+
     return el;
   }
 
@@ -42,7 +76,7 @@ export function initGreetingWidget(userConfig = {}) {
     if (config.displayMode === 'bubble_immediate') {
       showBubbleGreeting();
     } else if (config.displayMode === 'bubble_delayed') {
-      setTimeout(showBubbleGreeting, config.delay);
+      setTimeout(showBubbleGreeting, config.delay * 1000);
     } else if (config.displayMode === 'window_only') {
       const bubble = document.querySelector(config.bubbleSelector);
       if (bubble) {


### PR DESCRIPTION
## Summary
- allow greeting widget configuration of quick replies and closable message
- interpret delay setting in seconds rather than milliseconds and document new options

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/symplibackup/package.json')*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af6b12b948832c8166b8963ba1b00b